### PR TITLE
Fix a bug in the MP4 Parser

### DIFF
--- a/lib/mp4/parser-impl.js
+++ b/lib/mp4/parser-impl.js
@@ -112,7 +112,7 @@ class ParserImpl {
 
         if (Utils.TRACK_TYPE_AUDIO === hdlrAtom.handlerType) {
             let audioAtom = stsdAtom.getAudioAtom();
-            if (audioAtom !== null) {
+            if (audioAtom !== null && audioAtom.extraData !== null) {
                 track = new AudioTrack();
                 samplePrototype = AudioSample.prototype;
                 track.channels = audioAtom.channels;
@@ -122,7 +122,7 @@ class ParserImpl {
             }
         } else if (Utils.TRACK_TYPE_VIDEO === hdlrAtom.handlerType) {
             let videoAtom = stsdAtom.getVideoAtom();
-            if (videoAtom !== null) {
+            if (videoAtom !== null && videoAtom.extraData !== null) {
                 track = new VideoTrack();
                 samplePrototype = VideoSample.prototype;
                 track.width = videoAtom.width;


### PR DESCRIPTION
Ignore track if it doesn't have proper codec information