### PR TITLE
Fix a bug in the MP4 Builder

### DIFF
--- a/lib/mp4/atoms/atom-hdlr.js
+++ b/lib/mp4/atoms/atom-hdlr.js
@@ -18,21 +18,21 @@ class AtomHDLR extends Atom {
 
     parse(buffer) {
         this.handlerType = buffer.toString('ascii', 8, 12);
-        this.componentName = buffer.toString('ascii', 16);
+        this.componentName = buffer.toString('ascii', 24, buffer.indexOf(0, 24));
     }
 
     build(buffer, offset) {
         // header
         buffer.writeUInt32BE(this.bufferSize(), offset);
         buffer.write(this.type(), offset + 4);
-        // handler name
+        // handler type
         buffer.write(this.handlerType.substring(0, 4), offset + 16);
         // component name
-        buffer.write(this.componentName.substring(0, 16), offset + 24);
+        buffer.write(this.componentName.substring(0, 12), offset + 32);
     }
 
     bufferSize() {
-        return 48;
+        return 45;
     }
 
 }

--- a/lib/mp4/builder-impl.js
+++ b/lib/mp4/builder-impl.js
@@ -82,7 +82,7 @@ class BuilderImpl {
         // Header
         let ftypAtom = Utils.createAtom(Utils.ATOM_FTYP);
         ftypAtom.majorBrand = 'isom';
-        ftypAtom.minorVersion = 0;
+        ftypAtom.minorVersion = 0x200;
         ftypAtom.compatibleBrands = ['isom', 'iso2', 'mp41'];
         let codecBrand = null;
 

--- a/lib/mp4/utils.js
+++ b/lib/mp4/utils.js
@@ -36,8 +36,6 @@ module.exports = {
     COMPONENT_NAME_VIDEO: 'VideoHandler',
     COMPONENT_NAME_AUDIO: 'SoundHandler',
 
-    COMPRESSOR_NAME: 'NodeVideoLibrary', // should be exactly 16 symbols
-
     createAtom: function createAtom(type) {
         let AtomClass = require('./atoms/atom-' + type);
         return new AtomClass();

--- a/lib/mp4/video-sample-atom.js
+++ b/lib/mp4/video-sample-atom.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Atom = require('./atom');
-const Utils = require('./utils');
 
 const VIDEO_DPI = 72 << 16;
 const VIDEO_DEPTH = 24;
@@ -58,8 +57,6 @@ class VideoSampleAtom extends Atom {
         buffer.writeUInt32BE(VIDEO_DPI, offset + 40);
         // frame count
         buffer.writeUInt16BE(1, offset + 48);
-        // compressor name
-        buffer.write(Utils.COMPRESSOR_NAME.substring(0, 16), offset + 50);
         // depth
         buffer.writeUInt16BE(VIDEO_DEPTH, offset + 82);
         // color table id


### PR DESCRIPTION
HDLR atom:
- Use the correct atom size
- Use the correct position for the component name

FTYP atom:
- Set minor version to `0x200`

Video sample atom:
- Get rid of the useless encoder name