### PR TITLE
Fix parsing component name in the HDLR atom

### DIFF
--- a/lib/mp4/atoms/atom-hdlr.js
+++ b/lib/mp4/atoms/atom-hdlr.js
@@ -18,7 +18,8 @@ class AtomHDLR extends Atom {
 
     parse(buffer) {
         this.handlerType = buffer.toString('ascii', 8, 12);
-        this.componentName = buffer.toString('ascii', 24, buffer.indexOf(0, 24));
+        let nullIndex = buffer.indexOf(0, 24);
+        this.componentName = buffer.toString('ascii', 24, nullIndex > -1 ? nullIndex : undefined);
     }
 
     build(buffer, offset) {

--- a/test/hls-sample-counter.js
+++ b/test/hls-sample-counter.js
@@ -7,7 +7,7 @@ const VideoSample = require('../lib/video-sample');
 const chai = require('chai');
 const expect = chai.expect;
 
-describe('SampleCounter', function () {
+describe('HLSSampleCounter', function () {
     before(function () {
         this.counter = new SampleCounter();
         this.audioSample = new AudioSample();

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -14,7 +14,17 @@ function randInt(min, max) {
     return min + Math.floor(Math.random() * (max - min));
 }
 
+function randString(size) {
+    size = size || 0;
+    let chars = new Array(size);
+    for (let i = 0; i < size; i++) {
+        chars[i] = Math.random().toString(36)[2];
+    }
+    return chars.join('');
+}
+
 module.exports = {
     tempFile: tempFile,
     randInt: randInt,
+    randString: randString,
 };

--- a/test/mp4-atoms/atom-hdlr.js
+++ b/test/mp4-atoms/atom-hdlr.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const Atom = require('../../lib/mp4/atoms/atom-hdlr');
+
+const chai = require('chai');
+const expect = chai.expect;
+
+const Utils = require('../lib/utils');
+
+describe('hdlr', function () {
+    describe('#parse()', function () {
+        it('should parse a well-built buffer', function () {
+            let handlerType = Utils.randString(4);
+            for (let i = 0; i <= 13; i++) {
+                let componentName = Utils.randString(i);
+
+                let buffer = Buffer.alloc(37);
+                buffer.write(handlerType, 8);
+                buffer.write(componentName, 24);
+
+                let atom = new Atom();
+                atom.parse(buffer);
+
+                expect(atom.handlerType).to.be.equal(handlerType);
+                expect(atom.componentName).to.be.equal(componentName);
+            }
+        });
+    });
+
+    describe('#build()', function () {
+        it('should build a correct buffer', function () {
+            let handlerType = Utils.randString(4);
+            let componentName = Utils.randString(12);
+
+            let atom = new Atom();
+            atom.handlerType = handlerType;
+            atom.componentName = componentName;
+
+            let buffer = Buffer.alloc(45);
+            buffer.write(handlerType, 8);
+            buffer.write(componentName, 24);
+
+            atom.build(buffer, 0);
+
+            expect(buffer.readUInt32BE(0)).to.be.equal(buffer.length);
+            expect(buffer.toString('ascii', 4, 8)).to.be.equal('hdlr');
+            expect(buffer.toString('ascii', 16, 20)).to.be.equal(handlerType);
+            expect(buffer.toString('ascii', 32, 44)).to.be.equal(componentName);
+
+            atom = new Atom();
+            atom.parse(buffer.subarray(8));
+
+            expect(atom.handlerType).to.be.equal(handlerType);
+            expect(atom.componentName).to.be.equal(componentName);
+        });
+    });
+
+});

--- a/test/mp4-atoms/index.js
+++ b/test/mp4-atoms/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('MP4Atoms', function () {
+
+    require('./atom-hdlr');
+
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -6,10 +6,11 @@ describe('node-video-lib', function () {
     require('./buffer-utils');
     require('./flv-parser');
     require('./hls-packetizer');
+    require('./hls-sample-counter');
     require('./indexer');
     require('./movie-parser');
     require('./mp4-parser');
     require('./mp4-builder');
-    require('./sample-counter');
+    require('./mp4-atoms');
 
 });


### PR DESCRIPTION
Current behaviour of the component name parsing expect the `\0` symbol at the end of the string representation in the buffer. In case of lack of the `\0` symbol it fails to parse the component name. This modification fixes such a problem.