### PR TITLE
Use Buffer.subarray instead of Buffer.slice

### DIFF
--- a/lib/codecs/codec-h264.js
+++ b/lib/codecs/codec-h264.js
@@ -49,7 +49,7 @@ class CodecH264 extends Codec {
     _readNalUnit() {
         let length = this.extraData.readUInt16BE(this._pos);
         this._pos += 2;
-        let unit = this.extraData.slice(this._pos, this._pos + length);
+        let unit = this.extraData.subarray(this._pos, this._pos + length);
         this._pos += length;
         return unit;
     }

--- a/lib/codecs/codec-h265.js
+++ b/lib/codecs/codec-h265.js
@@ -72,7 +72,7 @@ class CodecH265 extends Codec {
     _readNalUnit() {
         let length = this.extraData.readUInt16BE(this._pos);
         this._pos += 2;
-        let unit = this.extraData.slice(this._pos, this._pos + length);
+        let unit = this.extraData.subarray(this._pos, this._pos + length);
         this._pos += length;
         return unit;
     }

--- a/lib/codecs/parser.js
+++ b/lib/codecs/parser.js
@@ -12,7 +12,7 @@ class Parser {
         let codecName = extraData.toString('ascii', 0, 4);
         let ParserClass = PARSERS[codecName];
         if (ParserClass) {
-            let parser = new ParserClass(extraData.slice(4, extraData.length));
+            let parser = new ParserClass(extraData.subarray(4, extraData.length));
             parser.parse();
             return parser;
         }

--- a/lib/fragment-reader.js
+++ b/lib/fragment-reader.js
@@ -60,7 +60,7 @@ class FragmentReader {
 
         return fragment.samples.map((sample, i) => {
             let entry = entries[i];
-            return buffers[entry.bufferIndex].buffer.slice(entry.bufferOffset, entry.bufferOffset + entry.size);
+            return buffers[entry.bufferIndex].buffer.subarray(entry.bufferOffset, entry.bufferOffset + entry.size);
         });
     }
 

--- a/lib/index/indexed-fragment-list.js
+++ b/lib/index/indexed-fragment-list.js
@@ -43,7 +43,7 @@ class IndexedFragmentList extends FragmentList {
                 width: 0,
                 height: 0,
             };
-            this.video.extraData = bufHeader.slice(pos, pos + videoExtraDataLength); pos += videoExtraDataLength;
+            this.video.extraData = bufHeader.subarray(pos, pos + videoExtraDataLength); pos += videoExtraDataLength;
             let codecSize = bufHeader.readUInt16BE(pos); pos += 2;
             if (codecSize > 0) {
                 this.video.codec = bufHeader.toString('ascii', pos, pos + codecSize); pos += codecSize;
@@ -63,7 +63,7 @@ class IndexedFragmentList extends FragmentList {
                 duration: 0,
                 size: 0,
             };
-            this.audio.extraData = bufHeader.slice(pos, pos + audioExtraDataLength); pos += audioExtraDataLength;
+            this.audio.extraData = bufHeader.subarray(pos, pos + audioExtraDataLength); pos += audioExtraDataLength;
             let codecSize = bufHeader.readUInt16BE(pos); pos += 2;
             if (codecSize > 0) {
                 this.audio.codec = bufHeader.toString('ascii', pos, pos + codecSize); pos += codecSize;

--- a/lib/mp4/atoms/atom-mp4a.js
+++ b/lib/mp4/atoms/atom-mp4a.js
@@ -42,7 +42,7 @@ class AtomMP4A extends Atom {
             if (name === Utils.ATOM_ESDS) {
                 let atom = Utils.createAtom(name);
                 if (atom !== null) {
-                    atom.parse(buffer.slice(offset, offset + size - 8));
+                    atom.parse(buffer.subarray(offset, offset + size - 8));
                     this.streamId = atom.streamId;
                     if (atom.extraData) {
                         this.extraData = Buffer.allocUnsafe(4 + atom.extraData.length);

--- a/lib/mp4/atoms/atom-stsd.js
+++ b/lib/mp4/atoms/atom-stsd.js
@@ -22,7 +22,7 @@ class AtomSTSD extends ContainerAtom {
     }
 
     parse(buffer) {
-        super.parse(buffer.slice(8));
+        super.parse(buffer.subarray(8));
     }
 
     build(buffer, offset) {

--- a/lib/mp4/container-atom.js
+++ b/lib/mp4/container-atom.js
@@ -57,7 +57,7 @@ class ContainerAtom extends Atom {
             if (this.availableAtoms().indexOf(name) !== -1) {
                 let atom = Utils.createAtom(name);
                 if (atom !== null) {
-                    atom.parse(buffer.slice(offset, offset + size - 8));
+                    atom.parse(buffer.subarray(offset, offset + size - 8));
                     this.addAtom(atom);
                 }
             }

--- a/lib/mp4/video-sample-atom.js
+++ b/lib/mp4/video-sample-atom.js
@@ -34,7 +34,7 @@ class VideoSampleAtom extends Atom {
                 break;
             }
             if (type === this.extraType()) {
-                this.extraData = buffer.slice(offset - 4, offset + size - 4);
+                this.extraData = buffer.subarray(offset - 4, offset + size - 4);
                 break;
             }
             offset += size - 8;


### PR DESCRIPTION
`Buffer.slice` is deprecated and might be removed in future. `Buffer.subarray` should be used instead.