### PR TITLE
pref: FragmentReader optimization

### DIFF
--- a/lib/fragment-reader.js
+++ b/lib/fragment-reader.js
@@ -31,54 +31,47 @@ class FragmentReader {
         }
         entries.sort((a, b) => a.offset - b.offset);
 
-        // collection of read operations
-        const reads = [];
-        let currentRead = null;
-        for (let i = 0; i < sampleCount; i++) {
-            const entry = entries[i];
-
-            if (!currentRead) {
-                currentRead = {
-                    start: entry.offset,
-                    end: entry.offset + entry.size,
-                    entries: [entry],
-                };
-                reads.push(currentRead);
-                continue;
-            }
-
-            const endOfCurrentBatch = currentRead.end;
-            const gapSize = entry.offset - endOfCurrentBatch;
-            const newEnd = entry.offset + entry.size;
-            const totalSizeIfMerged = newEnd - currentRead.start;
-
-            if (totalSizeIfMerged <= MAX_BUFFER_SIZE && gapSize <= MAX_GAP_SIZE) {
-                currentRead.end = newEnd;
-                currentRead.entries.push(entry);
-            } else {
-                currentRead = {
-                    start: entry.offset,
-                    end: newEnd,
-                    entries: [entry],
-                };
-                reads.push(currentRead);
-            }
-        }
-
-        // read data
         const result = new Array(sampleCount);
         const reader = SourceReader.create(source);
-        for (let i = 0; i < reads.length; i++) {
-            const batch = reads[i];
-            const batchSize = batch.end - batch.start;
-            const buffer = Buffer.allocUnsafe(batchSize);
-            reader.read(buffer, batch.start);
 
-            for (let j = 0, l = batch.entries.length; j < l; j++) {
-                const entry = batch.entries[j];
-                const start = entry.offset - batch.start;
-                const end = start + entry.size;
-                result[entry.index] = buffer.subarray(start, end);
+        // iterate and process batches immediately
+        let batchStartIndex = 0;
+        let batchOffsetStart = entries[0].offset;
+        let batchOffsetEnd = batchOffsetStart + entries[0].size;
+
+        for (let i = 1; i <= sampleCount; i++) {
+            const entry = i < sampleCount ? entries[i] : null;
+            let isMergeable = false;
+
+            if (entry) {
+                const gapSize = entry.offset - batchOffsetEnd;
+                const newEnd = entry.offset + entry.size;
+                const totalSizeIfMerged = newEnd - batchOffsetStart;
+
+                if (totalSizeIfMerged <= MAX_BUFFER_SIZE && gapSize <= MAX_GAP_SIZE) {
+                    batchOffsetEnd = newEnd;
+                    isMergeable = true;
+                }
+            }
+
+            if (!isMergeable) {
+                const batchSize = batchOffsetEnd - batchOffsetStart;
+                const buffer = Buffer.allocUnsafe(batchSize);
+
+                reader.read(buffer, batchOffsetStart);
+
+                for (let j = batchStartIndex; j < i; j++) {
+                    const batchEntry = entries[j];
+                    const offsetStart = batchEntry.offset - batchOffsetStart;
+                    const offsetEnd = offsetStart + batchEntry.size;
+                    result[batchEntry.index] = buffer.subarray(offsetStart, offsetEnd);
+                }
+
+                if (entry) {
+                    batchStartIndex = i;
+                    batchOffsetStart = entry.offset;
+                    batchOffsetEnd = batchOffsetStart + entry.size;
+                }
             }
         }
 

--- a/test/hls-packetizer.js
+++ b/test/hls-packetizer.js
@@ -20,8 +20,8 @@ const MP4_AAC_ONLY_FILE = './resources/boomstream_audio.mp4';
 const shouldPacketize = function () {
     describe('when fragment is valid', function () {
         before(function () {
-            let fragmentList = FragmentListBuilder.build(this.movie, 5/*Utils.randInt(3, 10)*/);
-            this.fragment = fragmentList.get(0/*Utils.randInt(0, fragmentList.count())*/);
+            let fragmentList = FragmentListBuilder.build(this.movie, Utils.randInt(3, 10));
+            this.fragment = fragmentList.get(Utils.randInt(0, fragmentList.count()));
             this.sampleBuffers = FragmentReader.readSamples(this.fragment, this.file);
         });
 


### PR DESCRIPTION
`FragmentReader` optimization:
- Remove intermediate `reads` and `currentRead.entries` arrays to reduce GC pressure.
- Replace two-pass logic (group then read) with a single-pass loop.
- Use integer indices to define batch ranges instead of `Array.push`.

Other:
- Revert temporary changes in the `HLSPacketizer` unit tests.