### PR TITLE
fix(video): patch initial HEVC CRA to BLA to resolve Open GOP artifacts

### DIFF
--- a/lib/hls/packetizer-impl.js
+++ b/lib/hls/packetizer-impl.js
@@ -39,9 +39,11 @@ class PacketizerImpl {
         if (this.fragment.hasVideo()) {
             this._videoCodecInfo = CodecParser.parse(this.fragment.videoExtraData);
             this._videoConfig = this._buildVideoConfig();
+            this._isH265 = this._videoCodecInfo.type() === CodecUtils.CODEC_H265;
         } else {
             this._videoCodecInfo = null;
             this._videoConfig = null;
+            this._isH265 = false;
         }
     }
 
@@ -55,6 +57,7 @@ class PacketizerImpl {
         buffersLength += header.length;
 
         // Write samples
+        let fixOpenGop = true;
         for (let i = 0, l = this.fragment.samples.length; i < l; i++) {
             const sample = this.fragment.samples[i];
             const buffer = this.sampleBuffers[i];
@@ -66,9 +69,10 @@ class PacketizerImpl {
                 buffersLength += audioBuffer.length;
             } else if (sample instanceof VideoSample) {
                 const ptsTime = TIME_OFFSET + Math.round(PACKET_TIMESCALE * (sample.timestamp + sample.compositionOffset) / sample.timescale);
-                const videoBuffer = this._packVideoPayload(buffer, sample, ptsTime, dtsTime);
+                const videoBuffer = this._packVideoPayload(buffer, sample, ptsTime, dtsTime, fixOpenGop && sample.keyframe);
                 buffers.push(videoBuffer);
                 buffersLength += videoBuffer.length;
+                fixOpenGop = false;
             }
         }
 
@@ -115,9 +119,9 @@ class PacketizerImpl {
         return this._packPayload(data, sample, AUDIO_PID, dtsTime);
     }
 
-    _packVideoPayload(buffer, sample, ptsTime, dtsTime) {
+    _packVideoPayload(buffer, sample, ptsTime, dtsTime, fixOpenGop) {
         let payloadLength = 25 + buffer.length + (sample.keyframe ? this._videoConfig.length : 0);
-        if (this._videoCodecInfo.type() === CodecUtils.CODEC_H265) {
+        if (this._isH265) {
             payloadLength++;
         }
         let data = Buffer.allocUnsafe(payloadLength);
@@ -142,7 +146,7 @@ class PacketizerImpl {
         data[pos++] = 0;
         data[pos++] = 0;
         data[pos++] = 1;
-        if (this._videoCodecInfo.type() === CodecUtils.CODEC_H265) {
+        if (this._isH265) {
             data[pos++] = 70;
             data[pos++] = 0x01;
         } else {
@@ -160,6 +164,14 @@ class PacketizerImpl {
             // Convert AVCC -> Annex B
             while (pos < data.length) {
                 const nalSize = data.readUInt32BE(pos);
+                if (fixOpenGop && this._isH265) {
+                    const byte0 = data[pos + 4];
+                    const nalType = (byte0 & 0x7e) >> 1;
+                    if (nalType === 21) { // CRA, Clean Random Access
+                        const newNalType = 16; // BLA, Broken Link Access
+                        data[pos + 4] = (byte0 & 0x81) | (newNalType << 1);
+                    }
+                }
                 data.writeUInt32BE(1, pos);
                 pos += 4 + nalSize;
             }


### PR DESCRIPTION
H.265 streams with Open GOP structures (CRA frames) caused visual artifacts at chunk boundaries due to missing reference frames.

Changes:
- Implemented `fixOpenGop` logic in `_packVideoPayload` to rewrite CRA NALs (type 21) as BLA (type 16).
- Updated the sample loop to apply this patch strictly to the first video keyframe of the fragment.
- Optimized H.265 codec checks.

This forces the decoder to reset context at the start of a segment, eliminating pixelation.