### PR TITLE
feat: add maxFragmentDuration and bump index version to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Methods:
 
 * **relativeDuration()** - Movie duration in seconds
     * Return: *\<Number\>*
+* **maxFragmentDuration()** - Maximum fragment duration in seconds
+    * Return: *\<Number\>*
 * **count()** - Fragments count
     * Return: *\<Integer\>*
 * **size()** - Samples size

--- a/lib/fragment-list.js
+++ b/lib/fragment-list.js
@@ -36,6 +36,16 @@ class FragmentList {
         return this.duration || 0;
     }
 
+    maxFragmentDuration() {
+        const maxDuration = this.fragments
+            .reduce((max, fragment) => Math.max(max, fragment.duration), 0);
+
+        if (this.timescale) {
+            return maxDuration / this.timescale;
+        }
+        return maxDuration;
+    }
+
     size() {
         return [this.video, this.audio]
             .filter(info => info !== null)

--- a/lib/index/fragment-list-indexer.js
+++ b/lib/index/fragment-list-indexer.js
@@ -32,6 +32,9 @@ class FragmentListIndexer {
         }
         let buffer = Buffer.allocUnsafe(bufferSize);
 
+        let maxFragmentDurationPos = 0;
+        let maxFragmentDuration = 0;
+
         // Write header
         let pos = 0;
         buffer.write(Utils.INDEX_PREFIX, pos); pos += 3;
@@ -39,6 +42,8 @@ class FragmentListIndexer {
         buffer.writeUInt32BE(fragmentsOffset, pos); pos += 4;
         buffer.writeUInt32BE(fragmentList.fragments.length, pos); pos += 4;
         buffer.writeUInt32BE(fragmentList.fragmentDuration, pos); pos += 4;
+        // placeholder for max fragment duration
+        maxFragmentDurationPos = pos; pos += 8;
         BufferUtils.writeUInt64BE(buffer, fragmentList.duration, pos); pos += 8;
         buffer.writeUInt32BE(fragmentList.timescale, pos); pos += 4;
         if (fragmentList.video) {
@@ -77,6 +82,9 @@ class FragmentListIndexer {
         // Write fragments
         for (let i = 0, fLen = fragmentList.fragments.length; i < fLen; i++) {
             let fragment = fragmentList.fragments[i];
+            if (fragment.duration > maxFragmentDuration) {
+                maxFragmentDuration = fragment.duration;
+            }
             buffer.writeUInt32BE(fragment.samples.length, pos); pos += 4;
             buffer.writeUInt32BE(samplesOffset, pos); pos += 4;
             BufferUtils.writeUInt64BE(buffer, fragment.timestamp, pos); pos += 8;
@@ -94,6 +102,9 @@ class FragmentListIndexer {
                 }
             }
         }
+
+        // Write maxFragmentDuration
+        BufferUtils.writeUInt64BE(buffer, maxFragmentDuration, maxFragmentDurationPos);
 
         // Write file
         fs.ftruncateSync(fd, buffer.length);

--- a/lib/index/indexed-fragment-list.js
+++ b/lib/index/indexed-fragment-list.js
@@ -30,8 +30,13 @@ class IndexedFragmentList extends FragmentList {
         let pos = 0;
         this._fragmentsCount = bufHeader.readUInt32BE(pos); pos += 4;
         this.fragmentDuration = bufHeader.readUInt32BE(pos); pos += 4;
+        this._maxFragmentDuration = BufferUtils.readUInt64BE(bufHeader, pos); pos += 8;
         this.duration = BufferUtils.readUInt64BE(bufHeader, pos); pos += 8;
         this.timescale = bufHeader.readUInt32BE(pos); pos += 4;
+        if (this.timescale > 0) {
+            this._maxFragmentDuration /= this.timescale;
+        }
+
         let videoExtraDataLength = bufHeader.readUInt16BE(pos); pos += 2;
         if (videoExtraDataLength > 0) {
             this.video = {
@@ -76,6 +81,14 @@ class IndexedFragmentList extends FragmentList {
 
     createFragment() {
         throw new Error('Not supported');
+    }
+
+    chop() {
+        throw new Error('Not supported');
+    }
+
+    maxFragmentDuration() {
+        return this._maxFragmentDuration;
     }
 
     count() {

--- a/lib/index/utils.js
+++ b/lib/index/utils.js
@@ -2,9 +2,9 @@
 
 module.exports = {
     INDEX_PREFIX: 'idx',
-    INDEX_VERSION: 2,
+    INDEX_VERSION: 3,
 
-    HEADER_SIZE: 32,
+    HEADER_SIZE: 40,
     HEADER_VIDEO_SIZE: 26,
     HEADER_AUDIO_SIZE: 18,
     FRAGMENT_SIZE: 24,

--- a/test/fragment-list.js
+++ b/test/fragment-list.js
@@ -38,4 +38,20 @@ describe('FragmentList', function () {
         });
     });
 
+    describe('#maxFragmentDuration', function () {
+        it('should respond with max fragment duration', function () {
+            const fragmentList = new FragmentList();
+            fragmentList.timescale = 1000;
+
+            let fragment1 = fragmentList.createFragment(0);
+            fragment1.duration = 100;
+            let fragment2 = fragmentList.createFragment(10);
+            fragment2.duration = 200;
+            let fragment3 = fragmentList.createFragment(30);
+            fragment3.duration = 150;
+
+            expect(fragmentList.maxFragmentDuration()).to.be.closeTo(0.2, 0.001);
+        });
+    });
+
 });

--- a/test/indexer.js
+++ b/test/indexer.js
@@ -42,7 +42,7 @@ describe('FragmentListIndexer', function () {
                 expect(fs.fstatSync(this.indexFile).isFile()).to.be.equal(true),
                 expect(fs.fstatSync(this.indexFile).size).to.be.above(0),
                 expect(buffer.toString('ascii', 0, 3)).to.be.equal('idx'),
-                expect(buffer[3]).to.be.equal(2),
+                expect(buffer[3]).to.be.equal(3),
             ];
         });
     });
@@ -59,6 +59,7 @@ describe('FragmentListIndexer', function () {
                 expect(this.readedFragmentList.fragmentDuration).to.be.equal(this.fragmentList.fragmentDuration),
                 expect(this.readedFragmentList.count()).to.be.equal(this.fragmentList.count()),
                 expect(this.readedFragmentList.size()).to.be.equal(this.fragmentList.size()),
+                expect(this.readedFragmentList.maxFragmentDuration()).to.be.closeTo(this.fragmentList.maxFragmentDuration(), 0.001),
                 expect(this.readedFragmentList.duration).to.be.equal(this.fragmentList.duration),
                 expect(this.readedFragmentList.timescale).to.be.equal(this.fragmentList.timescale),
                 expect(this.readedFragmentList.video).to.be.deep.equal(this.fragmentList.video),


### PR DESCRIPTION
Add `maxFragmentDuration()` method to `FragmentList`. This returns the maximum duration among all fragments, which is required for calculating a precise HLS `#EXT-X-TARGETDURATION`.

BREAKING CHANGE:
The index file format version has been bumped from 2 to 3. The header size has increased from 32 to 40 bytes. Existing index files generated with version 2 are incompatible and must be regenerated.